### PR TITLE
Do not require PyQt5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     author_email="me@waleedkhan.name",
     license="GPLv3",
     install_requires=[
-        "PyQt5",
         "plover>=4.0.0.dev0",
     ],
     packages=find_packages(),


### PR DESCRIPTION
The distribution info are missing when installing from distribution package on Ubuntu / Arch Linux.

Note the documentation in `README.md` should probably be updated now that `textstat` is no longer used.